### PR TITLE
Update PHP and PHPUnit versions for PHP 8 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,9 +20,9 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "4.8.*"
+        "phpunit/phpunit": "^9.5"
     },
     "require": {
-        "php": ">=5.6.0"
+        "php": "^7.1 || ^8.0"
     }
 }


### PR DESCRIPTION
- Update php requirement from >=5.6.0 to ^7.1 || ^8.0
- Update phpunit requirement from 4.8.* to ^9.5

The library uses native PHP Reflection API which works with PHP 7.1+.